### PR TITLE
Minor fixes and updates

### DIFF
--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -1044,7 +1044,11 @@ class ProjectDF:
 
         df = pd.read_csv(summary_file)
 
-        df = df.loc[(df.n_matching > 500) & (df.matching_ratio > 0.1)]
+        # Comment the following line that restricts the analysis of some tiles.
+        # All tiles provided will now be processed -- it's up to the user to
+        # provide a meaningful list of tiles.
+        #
+        # df = df.loc[(df.n_matching > 500) & (df.matching_ratio > 0.1)]
 
         pdf_ids = df.puck_barcode_file_id.to_list()
 

--- a/spacemake/snakemake/scripts/automated_analysis_create_report.Rmd
+++ b/spacemake/snakemake/scripts/automated_analysis_create_report.Rmd
@@ -321,6 +321,10 @@ y_mm_breaks <- paste0(y_mm_breaks * mm_diff / mm_dist, 'mm')
 x_breaks <- seq(x_limits[1], x_limits[2], px_by_um * mm_dist)
 y_breaks <- seq(y_limits[1], y_limits[2], px_by_um * mm_dist)
 
+puck_bead_size <- min(def_plot_bead_size, ifelse(snakemake@params$run_mode_variables$mesh_data,
+    snakemake@params$run_mode_variables$mesh_spot_diameter_um / 40,
+    snakemake@params$puck_variables$spot_diameter_um / 40))
+
 if(is_spatial){
     nhood_dat <- read_csv(snakemake@input$nhood_enrichment)
 }

--- a/spacemake/snakemake/scripts/automated_analysis_create_report.Rmd
+++ b/spacemake/snakemake/scripts/automated_analysis_create_report.Rmd
@@ -192,7 +192,10 @@ def_plot_bead_size <- ifelse(n_cells > 25000, 0.05, def_plot_bead_size)
 obs_colnames <- colnames(obs_df)
 
 # barcode file attached at the python level
-is_hexagonal <- snakemake@params$run_mode_variables$mesh_type == 'hexagon' & snakemake@params$run_mode_variables$mesh_data
+# is_hexagonal <- snakemake@params$run_mode_variables$mesh_type == 'hexagon' & snakemake@params$run_mode_variables$mesh_data
+is_hexagonal <- FALSE
+# commented out for now until ggplot corrects the geom_hex or until
+# we migrate to python-only reports.
 
 plot_umi_2d <- function(top_cutoff = FALSE){
     if(top_cutoff){

--- a/spacemake/snakemake/scripts/qc_sequencing_create_sheet.Rmd
+++ b/spacemake/snakemake/scripts/qc_sequencing_create_sheet.Rmd
@@ -667,7 +667,11 @@ for (run_mode_name in run_mode_names){
                        ttl = .$ttl,
                        cut_dist = .$cut_dist,
                        min_value = .$min_value,
-                       is_hexagonal=snakemake@params$run_modes[[run_mode_name]]$mesh_type == 'hexagon')
+                       is_hexagonal = FALSE
+                       # Comment this out for now until ggplot fixes the geom_hex or
+                       # until we migrate to python-only reports.
+                       # is_hexagonal=snakemake@params$run_modes[[run_mode_name]]$mesh_type == 'hexagon'
+                       )
                 } %>%
                 print()
         }


### PR DESCRIPTION
This PR has the following fixes:

- Removed a hard-coded threshold for analyzing pucks c5fad1b
- Hard-coded the `is_hexagonal` variable to be `FALSE` in the `Rmd` scripts f958ddb717b158d57cdd76502186ce96af27d03b. The error stems from a broken `geom_hex` within `ggplot` that results in wrong plots.
- Fixed an error in the `create_automated_report.Rmd` script d6eb21434e28032cfb5edffc7bfd52b1960bcdc6.