### PR TITLE
Don't add `spatial_barcode_min_matches` on `add_run_mode` with parent mode

### DIFF
--- a/spacemake/config.py
+++ b/spacemake/config.py
@@ -148,7 +148,6 @@ def get_run_mode_parser(required=True):
         "--spatial_barcode_min_matches",
         type=float,
         required=False,
-        default=0,
         help="minimum ratio (0, 1] of spatial barcode matches to further consider a puck"
         + "across the rest of the pipeline",
     )


### PR DESCRIPTION
This fixes #89 (Thanks Nikos!)