### PR TITLE
STAR index with shared memory

### DIFF
--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -37,6 +37,8 @@ bt2_rRNA_log = complete_data_root + "/rRNA.bowtie2.bam.log"
 star_index = 'species_data/{species}/{ref_name}/star_index'
 star_index_param = star_index
 star_index_file = star_index + '/SAindex'
+star_index_loaded = star_index + '/genomeLoad.done'
+star_index_unloaded = star_index + '/genomeUnload.done'
 
 bt2_index = 'species_data/{species}/{ref_name}/bt2_index'
 bt2_index_param = bt2_index + '/{ref_name}'
@@ -73,7 +75,11 @@ default_BT2_MAP_FLAGS = (
 # original rRNA mapping code used --very-fast-local and that was that.
 
 default_STAR_MAP_FLAGS = (
-    " --genomeLoad NoSharedMemory"
+    # before shared memory
+    # " --genomeLoad NoSharedMemory"
+    # with shared memory
+    " --genomeLoad LoadAndKeep"
+    " --limitBAMsortRAM 5000000000"
     " --outSAMprimaryFlag AllBestScore"
     " --outSAMattributes All"
     " --outSAMunmapped Within"
@@ -326,8 +332,10 @@ def get_map_inputs(wc, mapper="STAR"):
     mr = get_map_rule(wc)
     d = {
         'bam' : mr.input_path,
-        'index_file' : mr.map_index_file
+        'index_file' : mr.map_index_file,
     }
+    if mapper == 'STAR':
+        d['index_loaded'] = expand(star_index_loaded, species=mr.species, ref_name=mr.ref_name)
     if hasattr(mr, "ann_final"):
         d['annotation'] = mr.ann_final
 
@@ -465,7 +473,8 @@ rule map_reads_STAR:
         " --readFilesIn {input.bam}"
         " --readFilesCommand samtools view -f 4"
         " --readFilesType SAM SE"
-        " --sjdbGTFfile {params.auto[annotation]}"
+        # this needs to be removed for memory sharing
+        # " --sjdbGTFfile {params.auto[annotation]}"
         " --outFileNamePrefix {params.star_prefix}"
         " --runThreadN {threads}"
         " "
@@ -539,4 +548,74 @@ rule create_star_index:
              --genomeDir {output.index_dir} \
              --genomeFastaFiles {input.sequence} \
              --sjdbGTFfile {input.annotation}
+        """
+
+rule load_genome:
+    input:
+        star_index,
+        star_index_file
+    output:
+        temp(touch(star_index_loaded)),
+    shell:
+        """
+        STAR --genomeLoad LoadAndExit --genomeDir {input[0]}
+        """
+
+def get_final_mapped_bam():
+    out_files = []
+    df = project_df.df
+
+    # merged is ignored bc it does not come from mapping
+    df = df.loc[~df.is_merged]
+
+    for index, row in df.iterrows():
+        project_id, sample_id = index
+
+        for run_mode in row["run_mode"]:
+            run_mode_variables = project_df.config.get_run_mode(run_mode).variables
+            if run_mode_variables["polyA_adapter_trimming"]:
+                polyA_adapter_trimmed = ".polyA_adapter_trimmed"
+            else:
+                polyA_adapter_trimmed = ""
+
+            out_files = out_files + expand(
+                final_bam,
+                project_id=project_id,
+                sample_id=sample_id,
+                polyA_adapter_trimmed=polyA_adapter_trimmed,
+            )
+
+    return out_files
+
+def get_star_unloaded_flag(default_strategy="STAR:genome:final"):
+    out_files = []
+
+    for index, row in project_df.df.iterrows():
+        map_strategy = getattr(row, "map_strategy", default_strategy)
+        map_rules, _ = mapstr_to_targets(map_strategy, left=ubam_input, final=final_target)
+        is_merged = project_df.get_metadata(
+            "is_merged", project_id=index[0], sample_id=index[1]
+        )
+        if is_merged:
+            continue
+
+        for mr in map_rules:
+            if mr.mapper == "STAR":
+                out_files += expand(star_index_unloaded, species=row.species, ref_name=mr.ref_name)
+
+    return set(out_files)
+
+register_module_output_hook(get_star_unloaded_flag, "mapping.smk")
+
+
+rule unload_genome:
+    input:
+        bams=get_mapped_BAM_output(),
+        loaded_flag=star_index_loaded,
+        index_dir=star_index, # we put last so it is accessible
+    output:
+        temp(touch(star_index_unloaded))
+    shell:
+        """
+        STAR --genomeLoad Remove --genomeDir {input.index_dir}
         """


### PR DESCRIPTION
As of spacemake <=0.7.5, the STAR index is loaded separately for all samples into memory, which requires time and memory as discussed in #56. There, the use of snakemake's 'services' is proposed as a solution.

In this issue, alternatively, I modified the mapping snakemake workflow slightly to leverage STAR's built-in shared memory (based on linux shm). I used flags (`genomeLoad.done` and `genomeUnload.done`) so snakemake knows when to create and remove the memory map. These are temporary files that are automatically removed when the create-remove cycle is done.

Two notes that need validation/fixes before merging:

- If the job is interrupted, the `genomeLoad.done` temporary file might not be removed if the workflow stops unexpectedly.
- I had to remove the `--sjdbGTFfile` argument from the STAR call in `map_reads_STAR`, otherwise it is not possible to use `--genomeLoad LoadAndKeep`. From what I understood from the documentation, using `--sjdbGTFfile` during `STAR --runMode genomeGenerate` is equivalent to using it during mapping, but I might be wrong.
- Need to test with real datasets and see if the mapping output is different wrt <=0.7.5