### PR TITLE
Add support for updating R1/R2 in `update_sample`

### DIFF
--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -330,7 +330,8 @@ def get_action_sample_parser(parent_parser, action, func):
     elif action == "update":
         # add main variables parser
         parents.append(get_sample_main_variables_parser())
-
+        # add arguments for R1/R1, dge, longread
+        parents.append(get_data_parser())
         # add possibility to add extra info
         parents.append(get_sample_extra_info_parser())
     elif action == "merge":


### PR DESCRIPTION
Addresses #49 

It should merge smoothly with the other big branches (`fast-cmdline` et al). 

Edit: in fast-cmdline, this needs to be updated, instead:
https://github.com/rajewsky-lab/spacemake/blob/d047e5d381065e2f72de52a795b275018f44ee23/spacemake/cmdline.py#L347-L352