### PR TITLE
Using checkpoints for a single workflow

### DIFF
--- a/spacemake/cmdline.py
+++ b/spacemake/cmdline.py
@@ -790,47 +790,6 @@ def spacemake_run(args):
     # get the snakefile
     snakefile = os.path.join(os.path.dirname(__file__), "snakemake/main.smk")
     # run snakemake
-    preprocess_finished = snakemake.snakemake(
-        snakefile,
-        configfiles=[var.config_path],
-        cores=args["cores"],
-        dryrun=args["dryrun"],
-        targets=['get_stats_prealigned_barcodes'],
-        touch=args["touch"],
-        force_incomplete=args["rerun_incomplete"],
-        keepgoing=args["keep_going"],
-        printshellcmds=args["printshellcmds"],
-        config=config_variables,
-        delete_temp_output=True,
-    )
-
-    if preprocess_finished is False:
-        raise SpacemakeError("an error occurred while snakemake() ran")
-
-    # update valid pucks (above threshold) before continuing to downstream
-    # this performs counting of matching barcodes after alignment
-    pdf.update_project_df_barcode_matches(prealigned=True)
-    pdf.consolidate_pucks_merged_samples()
-    pdf.dump()
-
-    # whitelisting of barcodes
-    preprocess_finished = snakemake.snakemake(
-        snakefile,
-        configfiles=[var.config_path],
-        cores=args["cores"],
-        dryrun=args["dryrun"],
-        targets=['get_whitelist_barcodes'],
-        touch=args["touch"],
-        force_incomplete=args["rerun_incomplete"],
-        keepgoing=args["keep_going"],
-        printshellcmds=args["printshellcmds"],
-        config=config_variables,
-    )
-
-    pdf.update_project_df_barcode_matches()
-    pdf.dump()
-
-    # run snakemake quantification and reports
     analysis_finished = snakemake.snakemake(
         snakefile,
         configfiles=[var.config_path],

--- a/spacemake/cmdline.py
+++ b/spacemake/cmdline.py
@@ -801,7 +801,6 @@ def spacemake_run(args):
         keepgoing=args["keep_going"],
         printshellcmds=args["printshellcmds"],
         config=config_variables,
-        rerun_triggers=["mtime"],
     )
 
     if analysis_finished is False:

--- a/spacemake/cmdline.py
+++ b/spacemake/cmdline.py
@@ -801,6 +801,7 @@ def spacemake_run(args):
         keepgoing=args["keep_going"],
         printshellcmds=args["printshellcmds"],
         config=config_variables,
+        rerun_triggers=["mtime"],
     )
 
     if analysis_finished is False:

--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -1079,8 +1079,13 @@ class ProjectDF:
         from spacemake.map_strategy import validate_mapstr
         corrected_map_strategies = []
         # TODO: parse species from the current sample
+        if action == "add":
+            _i_species = kwargs["species"]
+        elif action == "update":
+            _i_species = self.df.loc[ix]['species']
+
         corrected_map_strategies.append(
-            validate_mapstr(map_strategy, config=self.config, species=self.df.loc[ix]['species'])
+            validate_mapstr(map_strategy, config=self.config, species=_i_species)
         )
         kwargs['map_strategy'] = corrected_map_strategies
 

--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -682,10 +682,11 @@ class ProjectDF:
         project_id: str,
         sample_id: str,
         puck_barcode_file_id: str,
+        **kwargs
     ):
         import numpy as np
         summary_file = puck_barcode_files_summary.format(
-            project_id=project_id, sample_id=sample_id
+            project_id=project_id, sample_id=sample_id, **kwargs
         )
 
         if not os.path.isfile(summary_file):

--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -1411,6 +1411,7 @@ class ProjectDF:
                     variable_name=variable, variable_value=variable_val, ix=ix
                 )
             else:
+                # TODO: here, might be why the map strategy is not formatted properly
                 # attach the deduced, consisten variable
                 kwargs[variable] = variable_val[0]
 

--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -652,24 +652,21 @@ class ProjectDF:
         self,
         project_id: str,
         sample_id: str,
+        polyA_adapter_trimmed: str = "",
     ):
         import pandas as pd
 
         summary_file = puck_barcode_files_summary.format(
-            project_id=project_id, sample_id=sample_id
+            project_id=project_id, sample_id=sample_id, polyA_adapter_trimmed=polyA_adapter_trimmed
         )
 
+        # will return all the pucks in the project_df for a (project, sample),
+        # if it cannot find the summary file (i.e., after n_intersect_sequences)
         if not os.path.isfile(summary_file):
             # print(f"looking for summary file: '{summary_file}'")
             return self.project_df_default_values["puck_barcode_file_id"]
 
         df = pd.read_csv(summary_file)
-
-        # Comment the following line that restricts the analysis of some tiles.
-        # All tiles provided will now be processed -- it's up to the user to
-        # provide a meaningful list of tiles.
-        #
-        # df = df.loc[(df.n_matching > 500) & (df.matching_ratio > 0.1)]
 
         pdf_ids = df.puck_barcode_file_id.to_list()
 

--- a/spacemake/project_df.py
+++ b/spacemake/project_df.py
@@ -113,6 +113,9 @@ class ProjectDF:
                 except pd.errors.EmptyDataError as e:
                     if attempts < 5:
                         # wait 5 seconds before retrying
+                        self.logger.warning(
+                            f"The file '{self.file_path}' seems to be empty. Trying again ({attempts}/5) in 5 seconds"
+                        )
                         time.sleep(5)
                         attempts = attempts + 1
                         continue

--- a/spacemake/snakemake/dropseq.smk
+++ b/spacemake/snakemake/dropseq.smk
@@ -50,6 +50,7 @@ rule filter_mm_reads:
         unpack(get_final_bam)
     output:
         pipe(final_bam_mm_included_pipe)
+    threads: 1
     shell:
         """
         python {repo_dir}/scripts/filter_mm_reads.py \

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -476,7 +476,7 @@ rule create_mesh_spatial_dge:
             project_id = wildcards.project_id,
             sample_id = wildcards.sample_id,
             puck_barcode_file_id = wildcards.puck_barcode_file_id,
-            **wildcards)
+            polyA_adapter_trimmed = wildcards.polyA_adapter_trimmed)
     run:
         adata = sc.read(input[0])
         if wildcards.spot_distance_um == 'hexagon':

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -142,7 +142,6 @@ rule run_analysis:
         ),
 
         # get flag for DGE (based on checkpoint, i.e., not explicitly generating files)
-        # TODO: when merging, issue: map strategy as list, should not be like that!
         get_expanded_pattern_project_sample(dge_out_done),
 
 

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -92,7 +92,6 @@ def get_module_outputs():
 ######################
 def checkpoint_puck_collection(wildcards):
     import shutil
-    print(wildcards)
     checkpoint_output = checkpoints.checkpoint_pucks.get(**wildcards).output[0]
     puck_barcode_file_ids = glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p
     puck_barcode_file_ids = list(set(puck_barcode_file_ids))

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -541,7 +541,7 @@ rule puck_collection_stitching:
         puck_metadata = lambda wildcards: project_df.get_puck_barcode_ids_and_files(
             project_id=wildcards.project_id, sample_id=wildcards.sample_id
         ),
-    run:
+    run:   
         _pc = puck_collection.merge_pucks_to_collection(
             # takes all input except the dge_out_done and puck_barcode_files
             input[:-1],

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -140,6 +140,7 @@ checkpoint checkpoint_pucks:
                 out.write("")
 
 def checkpoint_puck_files(wildcards):
+    import shutil
     checkpoint_output = checkpoints.checkpoint_pucks.get(**wildcards).output[0]
 
     non_spatial_pbf_id = project_df.project_df_default_values["puck_barcode_file_id"][0]
@@ -156,12 +157,18 @@ def checkpoint_puck_files(wildcards):
                  "automated_report": expand(automated_report,
                   puck_barcode_file_id=puck_barcode_file_ids, 
                   puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),
-                  # TODO: automated analysis with puck_collection
+                 "automated_report_collection": get_output_files(automated_report, 
+                  data_root_type = 'complete_data', downsampling_percentage='', 
+                  check_puck_collection=True,
+                  puck_barcode_file_matching_type='spatial_matching'),
                  "qc_report": expand(qc_sheet,
                   puck_barcode_file_id=puck_barcode_file_ids, 
-                  puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),}
-                  # TODO: QC report with puck_collection
-    print(out_files)
+                  puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),
+                 "qc_report_collection": get_output_files(qc_sheet, 
+                  data_root_type = 'complete_data', downsampling_percentage='', 
+                  check_puck_collection=True,
+                  puck_barcode_file_matching_type='spatial_matching'),}
+
     return out_files
 
 rule aggregate:

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -142,9 +142,7 @@ rule run_analysis:
         ),
 
         # get flag for DGE (based on checkpoint, i.e., not explicitly generating files)
-        # TODO: do not generate the files that have been generated already (especially DGEs and reports)
-        # TODO: check if the number of processed tiles is a subset of the puck_barcode_files_summary
-        # else, it means we've probably added some more tiles, and it would be convenient to recompute!
+        # TODO: when merging, issue: map strategy as list, should not be like that!
         get_expanded_pattern_project_sample(dge_out_done),
 
 

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -127,8 +127,12 @@ wildcard_constraints:
 ###################
 # Puck checkpoint #
 ###################
+<<<<<<< Updated upstream
 dge_out_dir = dge_out_prefix + "/{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
 dge_out_done = dge_out_prefix + "/{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.done"
+=======
+
+>>>>>>> Stashed changes
 
 checkpoint create_dge_chk:
     input:
@@ -145,13 +149,29 @@ checkpoint create_dge_chk:
 
 def create_dge_chk_files(wildcards):
     checkpoint_output = checkpoints.create_dge_chk.get(**wildcards).output[0]
+<<<<<<< Updated upstream
     out_files = expand(os.path.join(checkpoint_output, "{p}.chk"),
                 p=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p)
+=======
+    out_files = {"dge": expand(dge_out_h5ad,
+                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
+                "dge_obs": expand(dge_out_h5ad_obs,
+                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
+                "automated_report": expand(automated_report,
+                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
+                "qc_sheet": expand(qc_sheet,
+                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),}
+                # TODO: we need to add here the puck collection!
+>>>>>>> Stashed changes
     return out_files
 
 rule aggregate:
     input:
+<<<<<<< Updated upstream
         create_dge_chk_files
+=======
+        unpack(create_dge_chk_files)
+>>>>>>> Stashed changes
     output:
         touch(dge_out_done)
 
@@ -161,11 +181,25 @@ rule aggregate:
 rule run_analysis:
     input:
         get_module_outputs(),
+<<<<<<< Updated upstream
         get_expanded_pattern_project_sample(barcode_readcounts),
         get_expanded_pattern_project_sample(puck_count_prealigned_barcode_matches_summary),
         get_expanded_pattern_project_sample(puck_barcode_files_summary),
         get_expanded_pattern_project_sample(dge_out_done),
 
+=======
+        unpack(
+            get_output_files(
+                    fastqc_pattern, ext = fastqc_ext, mate=['1', '2'],
+                    data_root_type = 'complete_data', downsampling_percentage = '',
+                    filter_merged=True) 
+                if config['with_fastqc'] else []
+        ),
+        get_expanded_pattern_project_sample(barcode_readcounts),
+        get_expanded_pattern_project_sample(puck_count_prealigned_barcode_matches_summary),
+        get_expanded_pattern_project_sample(puck_barcode_files_summary),
+        get_expanded_pattern_project_sample(dge_out_done), # TODO: remove before creating
+>>>>>>> Stashed changes
 
 # rule aggregate:
 #     input:
@@ -203,12 +237,22 @@ rule run_analysis:
 ##############
 # DOWNSAMPLE #
 ##############
+<<<<<<< Updated upstream
 rule downsample:
     input:
         GetOutputFile(downsample_saturation_analysis,
             samples = config['samples'],
             projects = config['projects'],
             puck_barcode_file_matching_type = "spatial_matching")
+=======
+# TODO: enable saturation analysis with checkpoint
+# rule downsample:
+#     input:
+#         get_output_files(downsample_saturation_analysis,
+#             samples = config['samples'],
+#             projects = config['projects'],
+#             puck_barcode_file_matching_type = "spatial_matching")
+>>>>>>> Stashed changes
 
 #############
 # NOVOSPARC #

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -131,7 +131,7 @@ checkpoint checkpoint_pucks:
     input:
         bc_summary_file=puck_count_prealigned_barcode_matches_summary
     output:
-        dge_pointers=directory(dge_out_dir)
+        dge_pointers=temp(directory(dge_out_dir))
     run:
         os.mkdir(output.dge_pointers)
         barcodes_df = pd.read_csv(input.bc_summary_file)
@@ -168,7 +168,7 @@ rule aggregate:
     input:
         unpack(checkpoint_puck_files)
     output:
-        touch(dge_out_done)
+        temp(touch(dge_out_done))
 
 #############
 # Main rule #
@@ -193,7 +193,9 @@ rule run_analysis:
         # get_expanded_pattern_project_sample(puck_barcode_files_summary),
 
         # get flag for DGE (based on checkpoint, i.e., not explicitly generating files)
-        # TODO: remove upon running spacemake - recheck the intermediate files instead of the flag
+        # TODO: do not generate the files that have been generated already (especially DGEs and reports)
+        # TODO: check if the number of processed tiles is a subset of the puck_barcode_files_summary
+        # else, it means we've probably added some more tiles, and it would be convenient to recompute!
         get_expanded_pattern_project_sample(dge_out_done),
 
 

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -152,12 +152,15 @@ def checkpoint_puck_files(wildcards):
     puck_barcode_file_ids = list(set(puck_barcode_file_ids))
 
     out_files = {"dge": get_all_dges(wildcards, puck_barcode_file_ids),
-                 "dge_collection": get_all_dges_collection(wildcards, puck_barcode_file_ids)}
-                # "automated_report": expand(automated_report,
-                # puck_barcode_file_id=puck_barcode_file_ids, 
-                # puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),
-                # TODO: we need to add here the puck collection!
-                # TODO: qc sheet creation does not work
+                 "dge_collection": get_all_dges_collection(wildcards, puck_barcode_file_ids),
+                 "automated_report": expand(automated_report,
+                  puck_barcode_file_id=puck_barcode_file_ids, 
+                  puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),
+                  # TODO: automated analysis with puck_collection
+                 "qc_report": expand(qc_sheet,
+                  puck_barcode_file_id=puck_barcode_file_ids, 
+                  puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),}
+                  # TODO: QC report with puck_collection
     print(out_files)
     return out_files
 
@@ -197,13 +200,12 @@ rule run_analysis:
 ##############
 # DOWNSAMPLE #
 ##############
-# TODO: enable saturation analysis with checkpoint
-# rule downsample:
-#     input:
-#         get_output_files(downsample_saturation_analysis,
-#             samples = config['samples'],
-#             projects = config['projects'],
-#             puck_barcode_file_matching_type = "spatial_matching")
+rule downsample:
+    input:
+        get_output_files(downsample_saturation_analysis,
+            samples = config['samples'],
+            projects = config['projects'],
+            puck_barcode_file_matching_type = "spatial_matching")
 
 #################
 # MERGE SAMPLES #
@@ -635,7 +637,8 @@ rule create_qc_sheet:
         pbf_metrics = lambda wildcards: project_df.get_puck_barcode_file_metrics(
             project_id = wildcards.project_id,
             sample_id = wildcards.sample_id,
-            puck_barcode_file_id = wildcards.puck_barcode_file_id_qc),
+            puck_barcode_file_id = wildcards.puck_barcode_file_id_qc,
+            polyA_adapter_trimmed=wildcards.polyA_adapter_trimmed),
         is_spatial = lambda wildcards:
             project_df.is_spatial(wildcards.project_id, wildcards.sample_id,
                 puck_barcode_file_id=wildcards.puck_barcode_file_id_qc),
@@ -710,7 +713,8 @@ rule create_automated_report:
         pbf_metrics = lambda wildcards: project_df.get_puck_barcode_file_metrics(
             project_id = wildcards.project_id,
             sample_id = wildcards.sample_id,
-            puck_barcode_file_id = wildcards.puck_barcode_file_id_qc),
+            puck_barcode_file_id = wildcards.puck_barcode_file_id_qc,
+            polyA_adapter_trimmed=wildcards.polyA_adapter_trimmed),
         is_spatial = lambda wildcards:
             project_df.is_spatial(wildcards.project_id, wildcards.sample_id,
                 puck_barcode_file_id=wildcards.puck_barcode_file_id_qc),

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -15,7 +15,7 @@ import math
 import scanpy as sc
 
 from spacemake.preprocess.dge import dge_to_sparse_adata, attach_barcode_file,\
-    parse_barcode_file, load_external_dge, attach_puck_variables
+    parse_barcode_file, load_external_dge, attach_puck
 from spacemake.spatial.util import create_meshed_adata
 import spacemake.spatial.puck_collection as puck_collection
 from spacemake.project_df import ProjectDF
@@ -127,14 +127,7 @@ wildcard_constraints:
 ###################
 # Puck checkpoint #
 ###################
-<<<<<<< Updated upstream
-dge_out_dir = dge_out_prefix + "/{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
-dge_out_done = dge_out_prefix + "/{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.done"
-=======
-
->>>>>>> Stashed changes
-
-checkpoint create_dge_chk:
+checkpoint checkpoint_pucks:
     input:
         bc_summary_file=puck_count_prealigned_barcode_matches_summary
     output:
@@ -143,35 +136,34 @@ checkpoint create_dge_chk:
         os.mkdir(output.dge_pointers)
         barcodes_df = pd.read_csv(input.bc_summary_file)
         for p in barcodes_df['puck_barcode_file_id'].tolist():
-            print("create " + output.dge_pointers + f"/{p}.chk")
             with open(output.dge_pointers + f"/{p}.chk", "w") as out:
                 out.write("")
 
-def create_dge_chk_files(wildcards):
-    checkpoint_output = checkpoints.create_dge_chk.get(**wildcards).output[0]
-<<<<<<< Updated upstream
-    out_files = expand(os.path.join(checkpoint_output, "{p}.chk"),
-                p=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p)
-=======
-    out_files = {"dge": expand(dge_out_h5ad,
-                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
-                "dge_obs": expand(dge_out_h5ad_obs,
-                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
-                "automated_report": expand(automated_report,
-                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),
-                "qc_sheet": expand(qc_sheet,
-                puck_barcode_file_id=glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p, **wildcards),}
+def checkpoint_puck_files(wildcards):
+    checkpoint_output = checkpoints.checkpoint_pucks.get(**wildcards).output[0]
+
+    non_spatial_pbf_id = project_df.project_df_default_values["puck_barcode_file_id"][0]
+    puck_barcode_file_ids = glob_wildcards(os.path.join(checkpoint_output, "{p}.chk")).p
+
+    if non_spatial_pbf_id not in puck_barcode_file_ids:
+        puck_barcode_file_ids.append(non_spatial_pbf_id)
+
+    # deduplicate
+    puck_barcode_file_ids = list(set(puck_barcode_file_ids))
+
+    out_files = {"dge": get_all_dges(wildcards, puck_barcode_file_ids),
+                 "dge_collection": get_all_dges_collection(wildcards, puck_barcode_file_ids)}
+                # "automated_report": expand(automated_report,
+                # puck_barcode_file_id=puck_barcode_file_ids, 
+                # puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),
                 # TODO: we need to add here the puck collection!
->>>>>>> Stashed changes
+                # TODO: qc sheet creation does not work
+    print(out_files)
     return out_files
 
 rule aggregate:
     input:
-<<<<<<< Updated upstream
-        create_dge_chk_files
-=======
-        unpack(create_dge_chk_files)
->>>>>>> Stashed changes
+        unpack(checkpoint_puck_files)
     output:
         touch(dge_out_done)
 
@@ -180,14 +172,10 @@ rule aggregate:
 #############
 rule run_analysis:
     input:
+        # get outputs from registered hooks
         get_module_outputs(),
-<<<<<<< Updated upstream
-        get_expanded_pattern_project_sample(barcode_readcounts),
-        get_expanded_pattern_project_sample(puck_count_prealigned_barcode_matches_summary),
-        get_expanded_pattern_project_sample(puck_barcode_files_summary),
-        get_expanded_pattern_project_sample(dge_out_done),
 
-=======
+        # get FastQC reports
         unpack(
             get_output_files(
                     fastqc_pattern, ext = fastqc_ext, mate=['1', '2'],
@@ -195,56 +183,20 @@ rule run_analysis:
                     filter_merged=True) 
                 if config['with_fastqc'] else []
         ),
-        get_expanded_pattern_project_sample(barcode_readcounts),
-        get_expanded_pattern_project_sample(puck_count_prealigned_barcode_matches_summary),
-        get_expanded_pattern_project_sample(puck_barcode_files_summary),
-        get_expanded_pattern_project_sample(dge_out_done), # TODO: remove before creating
->>>>>>> Stashed changes
 
-# rule aggregate:
-#     input:
-#         # dge and puck collection (spatial stitching)
-#         unpack(GetAllDGEs()),
-#         unpack(get_all_dges_collection),
-#         # fastqc reports
-#         unpack(
-#             GetOutputFile(
-#                     fastqc_pattern, ext = fastqc_ext, mate=['1', '2'],
-#                     data_root_type = 'complete_data', downsampling_percentage = '',
-#                     filter_merged=True) 
-#                 if config['with_fastqc'] else []
-#         ),
-#         # spacemake reports
-#         GetOutputFile(automated_report, 
-#             data_root_type = 'complete_data', downsampling_percentage='', 
-#             puck_barcode_file_matching_type='spatial_matching'),
-#         GetOutputFile(automated_report, 
-#             data_root_type = 'complete_data', downsampling_percentage='', 
-#             check_puck_collection=True,
-#             puck_barcode_file_matching_type='spatial_matching'),
-#         GetOutputFile(qc_sheet, 
-#             data_root_type = 'complete_data', downsampling_percentage='', run_on_external=False, filter_merged=True,
-#             puck_barcode_file_matching_type='spatial_matching'),
-#         GetOutputFile(qc_sheet, 
-#             data_root_type = 'complete_data', downsampling_percentage='', run_on_external=False, filter_merged=True,
-#             check_puck_collection=True,
-#             puck_barcode_file_matching_type='spatial_matching')
-#     output:
-#         touch(aggregated_complete)
+        # # get barcode counts and other puck stats
+        # get_expanded_pattern_project_sample(barcode_readcounts),
+        # get_expanded_pattern_project_sample(puck_count_prealigned_barcode_matches_summary),
+        # get_expanded_pattern_project_sample(puck_barcode_files_summary),
 
+        # get flag for DGE (based on checkpoint, i.e., not explicitly generating files)
+        # TODO: remove upon running spacemake - recheck the intermediate files instead of the flag
+        get_expanded_pattern_project_sample(dge_out_done),
 
 
 ##############
 # DOWNSAMPLE #
 ##############
-<<<<<<< Updated upstream
-rule downsample:
-    input:
-        GetOutputFile(downsample_saturation_analysis,
-            samples = config['samples'],
-            projects = config['projects'],
-            puck_barcode_file_matching_type = "spatial_matching")
-=======
 # TODO: enable saturation analysis with checkpoint
 # rule downsample:
 #     input:
@@ -252,14 +204,6 @@ rule downsample:
 #             samples = config['samples'],
 #             projects = config['projects'],
 #             puck_barcode_file_matching_type = "spatial_matching")
->>>>>>> Stashed changes
-
-#############
-# NOVOSPARC #
-#############
-#rule novosparc:
-#    input:
-#        *get_novosparc_input_files(config)
 
 #################
 # MERGE SAMPLES #
@@ -578,7 +522,8 @@ rule create_mesh_spatial_dge:
         pbf_metrics = lambda wildcards: project_df.get_puck_barcode_file_metrics(
             project_id = wildcards.project_id,
             sample_id = wildcards.sample_id,
-            puck_barcode_file_id = wildcards.puck_barcode_file_id)
+            puck_barcode_file_id = wildcards.puck_barcode_file_id,
+            **wildcards)
     run:
         adata = sc.read(input[0])
         if wildcards.spot_distance_um == 'hexagon':

--- a/spacemake/snakemake/main.smk
+++ b/spacemake/snakemake/main.smk
@@ -494,7 +494,7 @@ rule create_mesh_spatial_dge:
 
 rule puck_collection_stitching:
     input:
-        unpack(get_puck_collection_stitching_input),
+        unpack(lambda wc: get_puck_collection_stitching_input(wc, to_mesh=False)),
         # the puck_barcode_files_summary is required for puck_metadata
         puck_barcode_files_summary
     output:
@@ -535,7 +535,7 @@ rule puck_collection_stitching:
 # TODO: collapse this with previous rule so we have a single point where we create the dge_spatial_collection
 rule puck_collection_stitching_meshed:
     input:
-        unpack(get_puck_collection_stitching_input),
+        unpack(lambda wc: get_puck_collection_stitching_input(wc, to_mesh=True)),
         # the puck_barcode_files_summary is required for puck_metadata
         puck_barcode_files_summary
     output:
@@ -791,8 +791,8 @@ def checkpoint_puck_files(wildcards):
     # deduplicate
     puck_barcode_file_ids = list(set(puck_barcode_file_ids))
 
+    # TODO: disabled the generation of puck collection
     out_files = {"dge": get_all_dges(wildcards, puck_barcode_file_ids),
-                 "dge_collection": get_all_dges_collection(wildcards, puck_barcode_file_ids),
                  "automated_report": expand(automated_report,
                   puck_barcode_file_id=puck_barcode_file_ids, 
                   puck_barcode_file_id_qc=puck_barcode_file_ids, **wildcards),

--- a/spacemake/snakemake/scripts/n_intersect_sequences.py
+++ b/spacemake/snakemake/scripts/n_intersect_sequences.py
@@ -73,7 +73,7 @@ def setup_parser(parser):
     parser.add_argument(
         "--target",
         type=str,
-        nargs="+",
+        nargs="*",
         help="target puck files against which search is performed",
         required=True,
     )
@@ -81,7 +81,7 @@ def setup_parser(parser):
     parser.add_argument(
         "--target-id",
         type=str,
-        nargs="+",
+        nargs="*",
         help="target puck ids for summary output",
         required=True,
     )
@@ -267,6 +267,12 @@ def cmdline():
 
     args = parser.parse_args()
 
+    df = pd.DataFrame(
+        columns=["puck_barcode_file", "n_barcodes", "n_matching", "matching_ratio"],
+    )
+    if len(args.target) == 0:
+        df.to_csv(args.summary_output, index=False)
+
     if len(args.target_id) != len(args.target):
         raise ValueError(
             f"target_id ({len(args.target_id)}) and target ({len(args.target)}) are different in size"
@@ -291,10 +297,6 @@ def cmdline():
     with mp.Pool(args.n_jobs) as pool:
         results = pool.map(find_matches, args.target)
 
-    df = pd.DataFrame(
-        results,
-        columns=["puck_barcode_file", "n_barcodes", "n_matching", "matching_ratio"],
-    )
     df["puck_barcode_file_id"] = args.target_id
     df['pass_threshold'] = 0
     df['pass_threshold'][df['matching_ratio'] > args.min_threshold] = 1

--- a/spacemake/snakemake/scripts/n_intersect_sequences.py
+++ b/spacemake/snakemake/scripts/n_intersect_sequences.py
@@ -267,10 +267,10 @@ def cmdline():
 
     args = parser.parse_args()
 
-    df = pd.DataFrame(
-        columns=["puck_barcode_file", "n_barcodes", "n_matching", "matching_ratio"],
-    )
     if len(args.target) == 0:
+        df = pd.DataFrame(
+            columns=["puck_barcode_file", "n_barcodes", "n_matching", "matching_ratio"],
+        )
         df.to_csv(args.summary_output, index=False)
 
     if len(args.target_id) != len(args.target):
@@ -297,6 +297,10 @@ def cmdline():
     with mp.Pool(args.n_jobs) as pool:
         results = pool.map(find_matches, args.target)
 
+    df = pd.DataFrame(
+        results,
+        columns=["puck_barcode_file", "n_barcodes", "n_matching", "matching_ratio"],
+    )
     df["puck_barcode_file_id"] = args.target_id
     df['pass_threshold'] = 0
     df['pass_threshold'][df['matching_ratio'] > args.min_threshold] = 1

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -414,13 +414,6 @@ def get_demux_indicator(wildcards):
     return expand(demux_indicator, demux_dir=demux_dir)
 
 
-def get_star_input_bam(wildcards):
-    if wildcards.polyA_adapter_trimmed == ".polyA_adapter_trimmed":
-        return {"reads": tagged_polyA_adapter_trimmed_bam}
-    else:
-        return {"reads": tagged_bam}
-
-
 def get_final_bam(wildcards):
     is_merged = project_df.get_metadata(
         "is_merged", project_id=wildcards.project_id, sample_id=wildcards.sample_id
@@ -467,6 +460,7 @@ def get_species_genome(wildcards, ref="genome"):
     return [files[ref]["sequence"]]
 
 
+# FLAG: unused
 def get_species_annotation(wildcards, ref="genome"):
     # This function will return the genome of a sample
     #    - annotation (.gtf file)
@@ -520,7 +514,7 @@ def get_rRNA_genome(wildcards):
 
     return [files["rRNA_genome"]]
 
-
+# FLAG: unused
 # TODO: refactor into map_strategy and/or delete
 def get_bt2_rRNA_index(wildcards):
     species = project_df.get_metadata(
@@ -615,7 +609,7 @@ def get_files_to_merge_snakemake(pattern):
 
     return get_merged_pattern
 
-
+# FLAG: unused
 def get_ribo_depletion_log(wildcards):
     is_merged = project_df.get_metadata(
         "is_merged", sample_id=wildcards.sample_id, project_id=wildcards.project_id
@@ -635,7 +629,7 @@ def get_top_barcodes(wildcards):
     else:
         return {"top_barcodes": top_barcodes_clean}
 
-
+# FLAG: unused
 def get_parsed_puck_file(wildcards):
     is_spatial = project_df.is_spatial(
         project_id=wildcards.project_id,
@@ -1051,6 +1045,7 @@ def get_automated_analysis_dge_input(wildcards):
             )["dge"]
         ]
 
+# FLAG: unused
 def get_novosparc_input_files(config):
     if (
         "reference_project_id" in config

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -131,6 +131,7 @@ def get_output_files(
     run_on_external=True,
     puck_barcode_file_matching_type="none",
     check_puck_collection=False,
+    puck_barcode_file_ids=[],
     qc=False,
     **kwargs,
 ):
@@ -166,18 +167,19 @@ def get_output_files(
             # and sample is external, skip
             continue
 
-        if puck_barcode_file_matching_type == "none":
-            # reset to empty string
-            puck_barcode_file_ids = []
-        elif puck_barcode_file_matching_type == "spatial":
-            # get only spatial
-            puck_barcode_file_ids = project_df.get_puck_barcode_ids_and_files(
-                project_id, sample_id
-            )[0]
-        elif puck_barcode_file_matching_type == "spatial_matching":
-            puck_barcode_file_ids = project_df.get_matching_puck_barcode_file_ids(
-                project_id=project_id, sample_id=sample_id
-            )
+        if puck_barcode_file_ids == []:
+            if puck_barcode_file_matching_type == "none":
+                # reset to empty string
+                puck_barcode_file_ids = []
+            elif puck_barcode_file_matching_type == "spatial":
+                # get only spatial
+                puck_barcode_file_ids = project_df.get_puck_barcode_ids_and_files(
+                    project_id, sample_id
+                )[0]
+            elif puck_barcode_file_matching_type == "spatial_matching":
+                puck_barcode_file_ids = project_df.get_matching_puck_barcode_file_ids(
+                    project_id=project_id, sample_id=sample_id
+                )
 
         if check_puck_collection:
             puck_vars = project_df.get_puck_variables(

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -147,6 +147,7 @@ def get_output_files(
     qc=False,
     **kwargs,
 ): 
+    import os
     out_files = []
     df = project_df.df
 
@@ -216,7 +217,11 @@ def get_output_files(
         ][0]
 
         if check_puck_collection and len(puck_barcode_file_ids) > 1:
-            puck_barcode_file_ids.append("puck_collection")
+            _puck_vars = project_df.get_puck_variables(project_id = project_id, sample_id = sample_id)
+            _coord_system = _puck_vars['coordinate_system']
+            if _coord_system != '' and os.path.exists(_coord_system):
+                puck_barcode_file_ids.append("puck_collection")
+
         if non_spatial_pbf_id not in puck_barcode_file_ids:
             puck_barcode_file_ids.append(non_spatial_pbf_id)
 

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -251,6 +251,13 @@ def get_all_dges(wildcards, puck_barcode_file_ids):
             set([project_df.project_df_default_values['puck_barcode_file_id'][0]]))
         )
 
+        # subset to the pucks for that sample
+        puck_barcode_file_ids = list(set(puck_barcode_file_ids).intersection(
+            set(project_df.get_matching_puck_barcode_file_ids(
+                    project_id=project_id, sample_id=sample_id
+                )))
+        )
+
         if "coordinate_system" in puck_vars.keys():
             coordinate_system = puck_vars["coordinate_system"]
             if (coordinate_system != '') and (len(puck_barcode_file_ids) > 1) and (os.path.exists(coordinate_system)):

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -200,8 +200,11 @@ def get_output_files(
             "puck_barcode_file_id"
         ][0]
 
-        if non_spatial_pbf_id not in puck_barcode_file_ids:
-            puck_barcode_file_ids.append(non_spatial_pbf_id)
+        if check_puck_collection:
+            puck_barcode_file_ids = "puck_collection"
+        else:
+            if non_spatial_pbf_id not in puck_barcode_file_ids:
+                puck_barcode_file_ids.append(non_spatial_pbf_id)
 
         for run_mode in row["run_mode"]:
             run_mode_variables = project_df.config.get_run_mode(run_mode).variables
@@ -212,9 +215,6 @@ def get_output_files(
                     polyA_adapter_trimmed = ".polyA_adapter_trimmed"
                 else:
                     polyA_adapter_trimmed = ""
-
-            if check_puck_collection:
-                puck_barcode_file_ids = "puck_collection"
 
             out_files = out_files + expand(
                 pattern,

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -239,6 +239,12 @@ def get_all_dges(wildcards, puck_barcode_file_ids):
     for index, row in df.iterrows():
         project_id, sample_id = index
 
+        puck_barcode_file_ids = list(set(puck_barcode_file_ids).intersection(
+            project_df.get_puck_barcode_ids_and_files(
+                        project_id, sample_id
+                    )[0])
+            )
+
         for run_mode in row["run_mode"]:
             if project_df.has_dge(project_id=project_id, sample_id=sample_id):
                 for pbf_id in puck_barcode_file_ids:

--- a/spacemake/snakemake/scripts/snakemake_helper_functions.py
+++ b/spacemake/snakemake/scripts/snakemake_helper_functions.py
@@ -246,16 +246,17 @@ def get_all_dges(wildcards, puck_barcode_file_ids):
             sample_id = sample_id
         )
 
-        # add the default so we account for "no_spatial_data"
-        puck_barcode_file_ids = list(set(puck_barcode_file_ids).union(
-            set([project_df.project_df_default_values['puck_barcode_file_id'][0]]))
+        # only pucks that are present in the sample
+        puck_barcode_file_ids = list(set(puck_barcode_file_ids).intersection(
+            set(project_df.get_puck_barcode_ids_and_files(
+                    project_id=project_id, sample_id=sample_id
+                )[0]))
         )
 
-        # subset to the pucks for that sample
-        puck_barcode_file_ids = list(set(puck_barcode_file_ids).intersection(
-            set(project_df.get_matching_puck_barcode_file_ids(
-                    project_id=project_id, sample_id=sample_id
-                )))
+        # add the default so we account for "no_spatial_data"
+        _default_non_spatial = project_df.project_df_default_values['puck_barcode_file_id'][0]
+        puck_barcode_file_ids = list(set(puck_barcode_file_ids).union(
+            set([_default_non_spatial]))
         )
 
         if "coordinate_system" in puck_vars.keys():

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -77,7 +77,7 @@ split_reads_read_type = split_reads_root + "read_type_num.txt"
 # post dropseq and QC #
 #######################
 
-qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{puck_barcode_file_id_qc}.html"
+qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}.html"
 reads_type_out = split_reads_read_type
 barcode_readcounts_suffix = "{polyA_adapter_trimmed}.txt.gz"
 barcode_readcounts = complete_data_root + "/out_readcounts" + barcode_readcounts_suffix
@@ -214,7 +214,7 @@ automated_analysis_root = (
     data_root + "/automated_analysis/{run_mode}/umi_cutoff_{umi_cutoff}"
 )
 automated_report_prefix = (
-    automated_analysis_root + "/{sample_id}_{puck_barcode_file_id_qc}_"
+    automated_analysis_root + "/{sample_id}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}_"
 )
 automated_report = automated_report_prefix + "automated_report.html"
 automated_analysis_result_file = automated_report_prefix + "results.h5ad"

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -77,7 +77,7 @@ split_reads_read_type = split_reads_root + "read_type_num.txt"
 # post dropseq and QC #
 #######################
 
-qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}.html"
+qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{run_mode}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}.html"
 reads_type_out = split_reads_read_type
 barcode_readcounts_suffix = "{polyA_adapter_trimmed}.txt.gz"
 barcode_readcounts = complete_data_root + "/out_readcounts" + barcode_readcounts_suffix

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -122,8 +122,10 @@ dge_out_summary = (
     + ".{n_beads}_beads_{puck_barcode_file_id}.summary.txt"
 )
 
-dge_chk = data_root + "/.dge_chk"
-dge_chk_created = data_root + "/.dge_chk/{puck_barcode_file_id}.chk2"
+
+# dge checkpoint
+dge_out_dir = dge_root + "/.flag.{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
+dge_out_done = dge_root + "/.flag.{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.done"
 
 # processed dge
 h5ad_dge_suffix = "{is_external}.h5ad"

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -105,9 +105,9 @@ stats_prealigned_spatial_barcodes = (
     complete_data_root
     + "/puck_barcode_files/stats_prealigned_spatial_barcodes_{puck_barcode_file_id}.csv"
 )
-puck_barcode_files_summary = complete_data_root + "/puck_barcode_files_summary.csv"
-puck_count_barcode_matches_summary = complete_data_root + "/puck_count_barcode_matches.csv"
-puck_count_prealigned_barcode_matches_summary = complete_data_root + "/puck_count_prealigned_barcode_matches.csv"
+puck_barcode_files_summary = complete_data_root + "/puck_barcode_files_summary{polyA_adapter_trimmed}.csv"
+puck_count_barcode_matches_summary = complete_data_root + "/puck_count_barcode_matches{polyA_adapter_trimmed}.csv"
+puck_count_prealigned_barcode_matches_summary = complete_data_root + "/puck_count_prealigned_barcode_matches{polyA_adapter_trimmed}.csv"
 
 # dge creation
 dge_root = data_root + "/dge"

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -77,7 +77,7 @@ split_reads_read_type = split_reads_root + "read_type_num.txt"
 # post dropseq and QC #
 #######################
 
-qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{run_mode}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}.html"
+qc_sheet = data_root + "/qc_sheets/qc_sheet_{sample_id}_{puck_barcode_file_id_qc}{polyA_adapter_trimmed}.html"
 reads_type_out = split_reads_read_type
 barcode_readcounts_suffix = "{polyA_adapter_trimmed}.txt.gz"
 barcode_readcounts = complete_data_root + "/out_readcounts" + barcode_readcounts_suffix
@@ -124,7 +124,7 @@ dge_out_summary = (
 
 # dge checkpoint
 dge_out_dir = dge_root + "/.flag{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
-dge_out_done = dge_root + "/.flag{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.{run_mode}.{umi_cutoff}.done"
+dge_out_done = dge_root + "/.flag{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.{run_mode}.{umi_cutoff}.dge.done"
 
 # processed dge
 h5ad_dge_suffix = "{is_external}.h5ad"
@@ -160,19 +160,19 @@ dge_spatial_obs = (
 dge_spatial_collection = (
     dge_out_prefix
     + dge_out_suffix
-    + ".spatial_beads_puck_collection"
+    + ".{n_beads}_beads_puck_collection"
     + h5ad_dge_suffix
 )
 dge_spatial_collection_obs = (
     dge_out_prefix
     + dge_out_suffix
-    + ".spatial_beads_puck_collection"
+    + ".{n_beads}_beads_puck_collection"
     + h5ad_dge_obs_suffix
 )
 
 # spatial + meshed dge
 dge_spatial_mesh_suffix = (
-    ".spatial_beads.mesh_{spot_diameter_um}_{spot_distance_um}_{puck_barcode_file_id}"
+    ".{n_beads}_beads.mesh_{spot_diameter_um}_{spot_distance_um}_{puck_barcode_file_id}"
 )
 dge_spatial_mesh_prefix = dge_out_prefix + dge_out_suffix + dge_spatial_mesh_suffix
 dge_spatial_mesh = dge_spatial_mesh_prefix + h5ad_dge_suffix
@@ -180,7 +180,7 @@ dge_spatial_mesh_obs = dge_spatial_mesh_prefix + h5ad_dge_obs_suffix
 
 # spatial + collection + meshed dge
 dge_spatial_collection_mesh_suffix = (
-    ".spatial_beads.mesh_{spot_diameter_um}_{spot_distance_um}_puck_collection"
+    ".{n_beads}_beads.mesh_{spot_diameter_um}_{spot_distance_um}_puck_collection"
 )
 dge_spatial_collection_mesh_prefix = dge_out_prefix + dge_out_suffix + dge_spatial_collection_mesh_suffix
 dge_spatial_collection_mesh = dge_spatial_collection_mesh_prefix + h5ad_dge_suffix

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -122,6 +122,9 @@ dge_out_summary = (
     + ".{n_beads}_beads_{puck_barcode_file_id}.summary.txt"
 )
 
+dge_chk = data_root + "/.dge_chk"
+dge_chk_created = data_root + "/.dge_chk/{puck_barcode_file_id}.chk2"
+
 # processed dge
 h5ad_dge_suffix = "{is_external}.h5ad"
 h5ad_dge_obs_suffix = "{is_external}.obs.csv"

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -122,10 +122,9 @@ dge_out_summary = (
     + ".{n_beads}_beads_{puck_barcode_file_id}.summary.txt"
 )
 
-
 # dge checkpoint
-dge_out_dir = dge_root + "/.flag.{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
-dge_out_done = dge_root + "/.flag.{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.done"
+dge_out_dir = dge_root + "/.flag{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}"
+dge_out_done = dge_root + "/.flag{dge_type}{dge_cleaned}{polyA_adapter_trimmed}{mm_included}.{n_beads}_beads{is_external}.{run_mode}.{umi_cutoff}.done"
 
 # processed dge
 h5ad_dge_suffix = "{is_external}.h5ad"


### PR DESCRIPTION
I adapted the workflow so it only needs to call a single `target` rule, using [checkpoints](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution). 

I have tested with the (tiny) test data and some real mouse brain samples - with and without spatial pucks, with and without puck collection, with and without meshing. Tests were run for the _main_, _merging_ and _downsampling_ workflows.

**Important**: I have tested all with snakemake 7.32.4. Previous versions (especially 5.x-6.x) might not work - workflow stops unexpectedly with apparently no error.