### PR TITLE
try unloading genome before start 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ project = 'spacemake'
 copyright = '2021-2023, Rajewsky lab'
 author = 'Tamas Ryszard Sztanka-Toth, Marvin Jens, Nikos Karaiskos, Nikolaus Rajewsky'
 
-version = '0.7.7'
+version = '0.7.8'
 release = version
 
 # -- General configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = spacemake
-version = 0.7.7
+version = 0.7.8
 author = Tamas Ryszard Sztanka-Toth, Marvin Jens, Nikos Karaiskos, Nikolaus Rajewsky 
 author_email = TamasRyszard.Sztanka-Toth@mdc-berlin.de
 description = A bioinformatic pipeline for the analysis of spatial transcriptomic data

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -563,7 +563,7 @@ rule load_genome:
         temp(directory(star_index_log_location))
     shell:
         """
-        {{STAR --genomeLoad Remove --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/ && }} || {{ echo "Could not remove shared memory genome for {input[0]}" }}
+        STAR --genomeLoad Remove --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/  || echo "Could not remove shared memory genome for {input[0]}"
         STAR --genomeLoad LoadAndExit --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/
         """
 

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -563,6 +563,7 @@ rule load_genome:
         temp(directory(star_index_log_location))
     shell:
         """
+        {STAR --genomeLoad Remove --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/ && } || { echo "Could not remove shared memory genome for {input[0]}" }
         STAR --genomeLoad LoadAndExit --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/
         """
 

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -563,7 +563,7 @@ rule load_genome:
         temp(directory(star_index_log_location))
     shell:
         """
-        {STAR --genomeLoad Remove --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/ && } || { echo "Could not remove shared memory genome for {input[0]}" }
+        {{STAR --genomeLoad Remove --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/ && }} || {{ echo "Could not remove shared memory genome for {input[0]}" }}
         STAR --genomeLoad LoadAndExit --genomeDir {input[0]}  --outFileNamePrefix {output[1]}/
         """
 

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -39,9 +39,8 @@ bt2_rRNA_log = complete_data_root + "/rRNA.bowtie2.bam.log"
 star_index = 'species_data/{species}/{ref_name}/star_index'
 star_index_param = star_index
 star_index_file = star_index + '/SAindex'
-temp_star_index_flag = tempfile.mkdtemp()
-star_index_loaded = star_index + temp_star_index_flag + '/genomeLoad.done'
-star_index_unloaded = star_index + temp_star_index_flag + '/genomeUnload.done'
+star_index_loaded = star_index + '/genomeLoad.done'
+star_index_unloaded = star_index + '/genomeUnload.done'
 star_index_log_location = 'species_data/{species}/{ref_name}/.star_index_logs'
 
 bt2_index = 'species_data/{species}/{ref_name}/bt2_index'


### PR DESCRIPTION
After unexpected exit (e.g., during STAR mapping and before running the rule `unload_genome`), it is possible that the genome remains in shared memory and then STAR is not happy when running `STAR LoadAndExit` (thus spacemake crashes).

This can be fixed with:

```bash
STAR --genomeLoad Remove --genomeDir <genome_dir>
```

But, here I implement a very simple fix: try running this command before `LoadAndExit`. 

I **prefer** this over checking whether the genome was loaded and not running `LoadAndExit`.