### PR TITLE
mm2 param handling

### DIFF
--- a/spacemake/map_strategy.py
+++ b/spacemake/map_strategy.py
@@ -92,10 +92,7 @@ default_map_flags = {
     ),
     "mm2": (
         " -x splice "
-    ),
-    "mm2_sr": (
-         " -x splice:sr "
-     )
+    )
 }
 
 
@@ -103,7 +100,6 @@ default_map_indices = {
     "bowtie2": smv.bt2_index_param,
     "STAR": smv.star_index,
     "mm2": smv.mm2_index,
-    "mm2_sr": smv.mm2_index,
 }
 
 default_counting_flavor_with_annotation = "default"
@@ -459,21 +455,15 @@ def get_mapped_BAM_output(
 
                 map_data["STAR_INDICES"][(mr.species, mr.ref_name)] = mr.map_index_param
 
-            elif mr.mapper in ("mm2", "mm2_sr"):
+            elif mr.mapper == "mm2":
                 mr.map_index_param = species_d[mr.ref_name].get(
                     "mm2_index", default_MM2_INDEX
                 )  # the parameter passed on to the mapper
                 mr.map_index = os.path.dirname(mr.map_index_param)  # the index_dir
                 mr.map_index_file = wc_fill(smv.mm2_index_file, mr)  # file present if the index is actually there
-                
-                if mr.mapper == "mm2_sr":
-                    mr.map_flags = species_d[mr.ref_name].get(
-                        "MM2_sr_flags", default_map_flags['mm2_sr']
-                    )
-                else:
-                    mr.map_flags = species_d[mr.ref_name].get(
-                        "MM2_flags", default_map_flags['mm2']
-                    )
+                mr.map_flags = species_d[mr.ref_name].get(
+                    "MM2_flags", default_map_flags['mm2']
+                )
 
             map_data["MAP_RULES_LKUP"][mr.out_path] = mr
             map_data["INDEX_FASTA_LKUP"][mr.map_index_file] = mr
@@ -504,7 +494,7 @@ def get_mapped_BAM_output(
                     final_log = smv.star_target_log_file.format(
                         ref_name=mr_final.ref_name,project_id=index[0], sample_id=index[1]
                     )
-                elif mr_final.mapper in ("mm2", "mm2_sr"): #mm2 final log
+                elif mr_final.mapper == "mm2": #mm2 final log
                     final_log = wc_fill(smv.mm2_target_log_file, mr_final)
                 
                 else:

--- a/spacemake/map_strategy.py
+++ b/spacemake/map_strategy.py
@@ -92,10 +92,10 @@ default_map_flags = {
     ),
     "mm2": (
         " -x splice "
-    )
-    # "mm2SR": (
-    #     " -ax sr "
-    # )
+    ),
+    "mm2_sr": (
+         " -x splice:sr "
+     )
 }
 
 
@@ -103,6 +103,7 @@ default_map_indices = {
     "bowtie2": smv.bt2_index_param,
     "STAR": smv.star_index,
     "mm2": smv.mm2_index,
+    "mm2_sr": smv.mm2_index,
 }
 
 default_counting_flavor_with_annotation = "default"
@@ -458,15 +459,24 @@ def get_mapped_BAM_output(
 
                 map_data["STAR_INDICES"][(mr.species, mr.ref_name)] = mr.map_index_param
 
-            elif mr.mapper == "mm2":
+            elif mr.mapper in ("mm2", "mm2_sr"):
                 mr.map_index_param = species_d[mr.ref_name].get(
                     "mm2_index", default_MM2_INDEX
                 )  # the parameter passed on to the mapper
                 mr.map_index = os.path.dirname(mr.map_index_param)  # the index_dir
                 mr.map_index_file = wc_fill(smv.mm2_index_file, mr)  # file present if the index is actually there
+                
                 mr.map_flags = species_d[mr.ref_name].get(
                     "MM2_flags", default_map_flags['mm2']
                 )
+                if mr.mapper == "mm2_sr":
+                    mr.map_flags = species_d[mr.ref_name].get(
+                        "MM2_sr_flags", default_map_flags['mm2_sr']
+                    )
+                else:
+                    mr.map_flags = species_d[mr.ref_name].get(
+                        "MM2_flags", default_map_flags['mm2']
+                    )
 
             map_data["MAP_RULES_LKUP"][mr.out_path] = mr
             map_data["INDEX_FASTA_LKUP"][mr.map_index_file] = mr

--- a/spacemake/map_strategy.py
+++ b/spacemake/map_strategy.py
@@ -466,9 +466,6 @@ def get_mapped_BAM_output(
                 mr.map_index = os.path.dirname(mr.map_index_param)  # the index_dir
                 mr.map_index_file = wc_fill(smv.mm2_index_file, mr)  # file present if the index is actually there
                 
-                mr.map_flags = species_d[mr.ref_name].get(
-                    "MM2_flags", default_map_flags['mm2']
-                )
                 if mr.mapper == "mm2_sr":
                     mr.map_flags = species_d[mr.ref_name].get(
                         "MM2_sr_flags", default_map_flags['mm2_sr']
@@ -500,15 +497,33 @@ def get_mapped_BAM_output(
                 final_log_name = smv.star_log_file.format(
                     project_id=index[0], sample_id=index[1]
                 )
-                final_log = smv.star_target_log_file.format(
-                    ref_name=lr.ref_name, project_id=index[0], sample_id=index[1]
-                )
-                # print("STAR_FINAL_LOG_SYMLINKS preparation", final_target, final_log_name, "->", final_log)
-                map_data["STAR_FINAL_LOG_SYMLINKS"][final_log_name] = final_log
-                map_data["REF_FOR_FINAL"][lr.link_path] = mr.ref_path
+
+                # lr.src_path is the BAM that is being designated as "final"
+                mr_final = map_data["MAP_RULES_LKUP"].get(lr.src_path)
+                if mr_final is None:
+                    raise SpacemakeError(
+                        f"Final BAM source '{lr.src_path}' not found in MAP_RULES_LKUP. "
+                        f"map_strategy='{map_strategy}'"
+                    )
+
+                if mr_final.mapper == "STAR": #STAR final log
+                    final_log_src = smv.star_target_log_file.format(
+                        project_id=index[0], sample_id=index[1], ref_name=mr_final.ref_name
+                    )
+                elif mr_final.mapper in ("mm2", "mm2_sr"): #mm2 final log
+                    final_log_src = wc_fill(smv.mm2_target_log_file, mr_final)
+                
+                else:
+                    raise SpacemakeError(
+                        f"Final mapper '{mr_final.mapper}' not supported for final log linking "
+                    )
+
+                map_data["STAR_FINAL_LOG_SYMLINKS"][final_log_name] = final_log_src
+
+                # IMPORTANT: use the final rule's ref_path (not the last mr from the loop)
+                map_data["REF_FOR_FINAL"][lr.link_path] = mr_final.ref_path
 
                 out_files.append(lr.link_path)
-
     # for k, v in sorted(map_data["MAP_RULES_LKUP"].items()):
     #     print(f"map_rules for '{k}'")
     #     print(v)

--- a/spacemake/map_strategy.py
+++ b/spacemake/map_strategy.py
@@ -497,30 +497,23 @@ def get_mapped_BAM_output(
                 final_log_name = smv.star_log_file.format(
                     project_id=index[0], sample_id=index[1]
                 )
-
-                # lr.src_path is the BAM that is being designated as "final"
+                
                 mr_final = map_data["MAP_RULES_LKUP"].get(lr.src_path)
-                if mr_final is None:
-                    raise SpacemakeError(
-                        f"Final BAM source '{lr.src_path}' not found in MAP_RULES_LKUP. "
-                        f"map_strategy='{map_strategy}'"
-                    )
 
                 if mr_final.mapper == "STAR": #STAR final log
-                    final_log_src = smv.star_target_log_file.format(
-                        project_id=index[0], sample_id=index[1], ref_name=mr_final.ref_name
+                    final_log = smv.star_target_log_file.format(
+                        ref_name=mr_final.ref_name,project_id=index[0], sample_id=index[1]
                     )
                 elif mr_final.mapper in ("mm2", "mm2_sr"): #mm2 final log
-                    final_log_src = wc_fill(smv.mm2_target_log_file, mr_final)
+                    final_log = wc_fill(smv.mm2_target_log_file, mr_final)
                 
                 else:
                     raise SpacemakeError(
                         f"Final mapper '{mr_final.mapper}' not supported for final log linking "
                     )
 
-                map_data["STAR_FINAL_LOG_SYMLINKS"][final_log_name] = final_log_src
+                map_data["STAR_FINAL_LOG_SYMLINKS"][final_log_name] = final_log
 
-                # IMPORTANT: use the final rule's ref_path (not the last mr from the loop)
                 map_data["REF_FOR_FINAL"][lr.link_path] = mr_final.ref_path
 
                 out_files.append(lr.link_path)

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -114,6 +114,9 @@ def get_map_inputs(wc, mapper="STAR"):
     #     d['index_loaded'] = load_index_if_needed(expand(star_index_loaded, species=mr.species, ref_name=mr.ref_name))
     if hasattr(mr, "ann_final"):
         d['annotation'] = mr.ann_final
+        # For minimap2, also add junction BED file when annotation exists
+        if mapper == "mm2" and mr.ann_final:
+            d['junc_bed'] = f"species_data/{mr.species}/{mr.ref_name}/annotation.bed"
 
     return d
 
@@ -133,11 +136,18 @@ def get_map_params(wc, output, mapper="STAR"):
                 f"samtools view --no-PG --threads=4 -T {ref} -C /dev/stdin -o {mr.out_path}"
             )
 
+    # For minimap2, add junc-bed flag when annotation exists
+    junc_bed_flag = ""
+    if mapper == "mm2" and hasattr(mr, "ann_final") and mr.ann_final:
+        junc_bed_path = f"species_data/{mr.species}/{mr.ref_name}/annotation.bed"
+        junc_bed_flag = f"--junc-bed {junc_bed_path}"
+
     return {
         'annotation_cmd' : annotation_cmd,
         'annotation' : mr.ann_final,
         'index' : mr.map_index_param,
         'flags' : mr.map_flags,
+        'junc_bed_flag' : junc_bed_flag,
     }
 
 ##############################################################################
@@ -204,7 +214,6 @@ rule map_reads_bowtie2:
 rule map_reads_mm2:
     input:
         unpack(lambda wc: get_map_inputs(wc, mapper='mm2')),
-        junc_bed=lambda wc: f"species_data/{wc.species}/{wc.ref_name}/annotation.bed"
     output:
         bam=mm2_mapped_bam,
         ubam=mm2_unmapped_bam,
@@ -217,7 +226,7 @@ rule map_reads_mm2:
     shell:
         "samtools fastq -f 4 -T '*' {input.bam} "
         " "
-        "| minimap2 -t {threads} -ay {params.auto[flags]} --junc-bed {input.junc_bed} {params.auto[index]} /dev/stdin 2> {log} "
+        "| minimap2 -t {threads} -ay {params.auto[flags]} {params.auto[junc_bed_flag]} {params.auto[index]} /dev/stdin 2> {log} "
         " "
         "| python {repo_dir}/scripts/splice_bam_header.py "
         "  --in-ubam {input.bam}"

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -10,7 +10,6 @@ references, each with its own sequence/FASTA file and optional annotation) and a
 The module takes over after pre-processing is done and hands over a "final.bam" or equivalent
 to all downstream steps (DGE generation, qc_sheets, ...).
 """
-
 # This is where all the python functions and string constants
 # live
 from spacemake.map_strategy import *
@@ -202,30 +201,32 @@ rule map_reads_bowtie2:
        
         # "sambamba sort -t {threads} -m 8G --tmpdir=/tmp/tmp.{wildcards.name} -l 6 -o {output} /dev/stdin "
 
+
 rule map_reads_mm2:
+    wildcard_constraints:
+        mapper="mm2|mm2_sr"
     input:
-        unpack(lambda wc: get_map_inputs(wc, mapper='mm2')),
+        unpack(lambda wc: get_map_inputs(wc, mapper=wc.mapper)),
     output:
-        bam=mm2_mapped_bam,
-        ubam=mm2_unmapped_bam,
-        star_log=star_target_log_file,
-    log: mm2_log
+        bam=mapped_bam,
+        ubam=unmapped_bam,
+        marker=mm2_target_log_file,
+    log:
+        mm2_log
     params:
-        auto = lambda wc, output: get_map_params(wc, output, mapper='mm2'),
+        auto=lambda wc, output: get_map_params(wc, output, mapper=wc.mapper),
     threads: 32
     shell:
         "samtools fastq -f 4 -T '*' {input.bam} "
         " "
         "| minimap2 -t {threads} -ay {params.auto[flags]} {params.auto[index]} /dev/stdin 2> {log} "
         " "
-        # fix the BAM header to accurately reflect the entire history of processing via PG records.
         "| python {repo_dir}/scripts/splice_bam_header.py "
         "  --in-ubam {input.bam}"
         " "
         "| tee >( {params.auto[annotation_cmd]} ) "
         "| samtools view -f 4 --threads=4 -Ch --no-PG > {output.ubam} "
-        " && touch {output.star_log}" # TODO find out who depends on this and make them read mm2 stats too
-
+        " && touch {output.marker}"
 
 # TODO: unify these two functions and get rid of the params in parse_ribo_log rule below.
 def get_ribo_log(wc):

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -202,18 +202,16 @@ rule map_reads_bowtie2:
         # "sambamba sort -t {threads} -m 8G --tmpdir=/tmp/tmp.{wildcards.name} -l 6 -o {output} /dev/stdin "
 
 rule map_reads_mm2:
-    wildcard_constraints:
-        mapper="mm2|mm2_sr"
     input:
-        unpack(lambda wc: get_map_inputs(wc, mapper=wc.mapper)),
+        unpack(lambda wc: get_map_inputs(wc, mapper='mm2')),
     output:
-        bam=mapped_bam,
-        ubam=unmapped_bam,
+        bam=mm2_mapped_bam,
+        ubam=mm2_unmapped_bam,
         log=mm2_target_log_file,
     log:
         mm2_log,
     params:
-        auto=lambda wc, output: get_map_params(wc, output, mapper=wc.mapper),
+        auto=lambda wc, output: get_map_params(wc, output, mapper='mm2'),
     threads: 32
     shell:
         "samtools fastq -f 4 -T '*' {input.bam} "

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -114,9 +114,10 @@ def get_map_inputs(wc, mapper="STAR"):
     #     d['index_loaded'] = load_index_if_needed(expand(star_index_loaded, species=mr.species, ref_name=mr.ref_name))
     if hasattr(mr, "ann_final"):
         d['annotation'] = mr.ann_final
-        # For minimap2, also add junction BED file when annotation exists
-        if mapper == "mm2" and mr.ann_final:
-            d['junc_bed'] = f"species_data/{mr.species}/{mr.ref_name}/annotation.bed"
+
+    # For minimap2, also add junction BED file when annotation exists
+    if mapper == "mm2" and hasattr(mr, "ann_path") and mr.ann_path:
+        d['junc_bed'] = species_reference_junc_bed.format(species=mr.species, ref_name=mr.ref_name)
 
     return d
 
@@ -138,8 +139,8 @@ def get_map_params(wc, output, mapper="STAR"):
 
     # For minimap2, add junc-bed flag when annotation exists
     junc_bed_flag = ""
-    if mapper == "mm2" and hasattr(mr, "ann_final") and mr.ann_final:
-        junc_bed_path = f"species_data/{mr.species}/{mr.ref_name}/annotation.bed"
+    if mapper == "mm2" and hasattr(mr, "ann_path") and mr.ann_path:
+        junc_bed_path = species_reference_junc_bed.format(species=mr.species, ref_name=mr.ref_name)
         junc_bed_flag = f"--junc-bed {junc_bed_path}"
 
     return {

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -204,6 +204,7 @@ rule map_reads_bowtie2:
 rule map_reads_mm2:
     input:
         unpack(lambda wc: get_map_inputs(wc, mapper='mm2')),
+        junc_bed=lambda wc: f"species_data/{wc.species}/{wc.ref_name}/annotation.bed"
     output:
         bam=mm2_mapped_bam,
         ubam=mm2_unmapped_bam,
@@ -216,7 +217,7 @@ rule map_reads_mm2:
     shell:
         "samtools fastq -f 4 -T '*' {input.bam} "
         " "
-        "| minimap2 -t {threads} -ay {params.auto[flags]} {params.auto[index]} /dev/stdin 2> {log} "
+        "| minimap2 -t {threads} -ay {params.auto[flags]} --junc-bed {input.junc_bed} {params.auto[index]} /dev/stdin 2> {log} "
         " "
         "| python {repo_dir}/scripts/splice_bam_header.py "
         "  --in-ubam {input.bam}"
@@ -370,6 +371,16 @@ rule create_minimap2_index:
         """
         mkdir -p {params.auto[map_index]}
         minimap2 -d {output} {input}
+        """
+
+rule create_junc_bed:
+    input:
+        species_reference_annotation
+    output:
+        "species_data/{species}/{ref_name}/annotation.bed"
+    shell:
+        """
+        paftools.js gff2bed {input} > {output}
         """
 
 rule create_star_index:

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -201,7 +201,6 @@ rule map_reads_bowtie2:
        
         # "sambamba sort -t {threads} -m 8G --tmpdir=/tmp/tmp.{wildcards.name} -l 6 -o {output} /dev/stdin "
 
-
 rule map_reads_mm2:
     wildcard_constraints:
         mapper="mm2|mm2_sr"
@@ -210,9 +209,9 @@ rule map_reads_mm2:
     output:
         bam=mapped_bam,
         ubam=unmapped_bam,
-        marker=mm2_target_log_file,
+        log=mm2_target_log_file,
     log:
-        mm2_log
+        mm2_log,
     params:
         auto=lambda wc, output: get_map_params(wc, output, mapper=wc.mapper),
     threads: 32
@@ -226,7 +225,7 @@ rule map_reads_mm2:
         " "
         "| tee >( {params.auto[annotation_cmd]} ) "
         "| samtools view -f 4 --threads=4 -Ch --no-PG > {output.ubam} "
-        " && touch {output.marker}"
+        " && touch {output.log}"
 
 # TODO: unify these two functions and get rid of the params in parse_ribo_log rule below.
 def get_ribo_log(wc):

--- a/spacemake/snakemake/mapping.smk
+++ b/spacemake/snakemake/mapping.smk
@@ -387,7 +387,7 @@ rule create_junc_bed:
     input:
         species_reference_annotation
     output:
-        "species_data/{species}/{ref_name}/annotation.bed"
+        species_reference_junc_bed
     shell:
         """
         paftools.js gff2bed {input} > {output}

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -77,6 +77,7 @@ mm2_index_log = mm2_index_param + ".log"
 
 species_reference_sequence = "species_data/{species}/{ref_name}/sequence.fa"
 species_reference_annotation = "species_data/{species}/{ref_name}/annotation.gtf"
+species_reference_junc_bed = "species_data/{species}/{ref_name}/annotation.bed"
 
 species_reference_annotation_compiled = (
     "species_data/{species}/{ref_name}/compiled_annotation"

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -40,8 +40,8 @@ bt2_mapped_log = log_dir + "/{ref_name}.bowtie2.log"
 
 mm2_mapped_bam = complete_data_root + "/{ref_name}.mm2.cram"
 mm2_unmapped_bam = complete_data_root + "/not_{ref_name}.mm2.cram"
-mm2_log = log_dir + "/{ref_name}.{mapper}.log"
-mm2_target_log_file = complete_data_root + "/mm2.{ref_name}.{mapper}.Log.final.out"
+mm2_log = log_dir + "/{ref_name}.mm2.log"
+mm2_target_log_file = complete_data_root + "/mm2.{ref_name}.Log.final.out"
 # special log file used for rRNA "ribo depletion" stats
 bt2_rRNA_log = complete_data_root + "/rRNA.bowtie2.cram.log"
 

--- a/spacemake/snakemake/variables.py
+++ b/spacemake/snakemake/variables.py
@@ -40,8 +40,8 @@ bt2_mapped_log = log_dir + "/{ref_name}.bowtie2.log"
 
 mm2_mapped_bam = complete_data_root + "/{ref_name}.mm2.cram"
 mm2_unmapped_bam = complete_data_root + "/not_{ref_name}.mm2.cram"
-mm2_log = log_dir + "/{ref_name}.mm2.log"
-
+mm2_log = log_dir + "/{ref_name}.{mapper}.log"
+mm2_target_log_file = complete_data_root + "/mm2.{ref_name}.{mapper}.Log.final.out"
 # special log file used for rRNA "ribo depletion" stats
 bt2_rRNA_log = complete_data_root + "/rRNA.bowtie2.cram.log"
 

--- a/tests/test_longread.py
+++ b/tests/test_longread.py
@@ -1,0 +1,18 @@
+import pytest
+import os
+from fixtures import initialized_root, with_species, sm, spacemake_dir
+
+def test_mm2_junc_bed(with_species):
+    """Test the --junc-bed wiring to mm2 mapping"""
+    os.chdir(with_species.as_posix())
+    sm(
+        "projects",
+        "add-sample",
+        "--project-id=test",
+        "--sample-id=test_mm2_junc_bed",
+        f"--R1={spacemake_dir}/test_data/simple.reads1.fastq.gz",
+        f"--R2={spacemake_dir}/test_data/simple.reads2.fastq.gz",
+        "--map-strategy=mm2:genome:final",
+        "--species=test_hsa",
+    )
+    sm("run", "-np", "--cores=8")


### PR DESCRIPTION
Generalized parameter handling for mapping flags. It started as parameter handling for minimap2 

1) Adding --junc-bed option (handled by converting gtf to bed12 at mapping.smk which is inputted to minimap2 mapping rule).
2) adding sr flag for short-read samples. First created a mapping strategy just for mm2 short reads in map_strategy.py but proved to be too bulky. Solution by Marvin: elegant config.yaml structure for parameter handling for mappers (below in the comments)